### PR TITLE
Add kids friendly chat UI

### DIFF
--- a/kids_chat.html
+++ b/kids_chat.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>KoalaMath Chat</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js"></script>
+<script type="module" src="https://unpkg.com/mathlive?module"></script>
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/tesseract.js@5.0.0/dist/tesseract.min.js"></script>
+<style>
+body {
+  font-family: 'Comic Sans MS', 'Comic Neue', cursive;
+  background:#fdf5e6;
+  margin:0;
+  padding:0;
+}
+#chat {
+  max-width: 600px;
+  margin: 20px auto;
+  background:white;
+  border-radius:10px;
+  padding:20px;
+  box-shadow:0 4px 10px rgba(0,0,0,0.1);
+}
+.message {
+  margin:10px 0;
+  padding:10px;
+  border-radius:10px;
+  background:#f0f8ff;
+}
+.message.user { background:#d1e7dd; text-align:right; }
+.message.bot { background:#fff3cd; }
+#input-area {
+  max-width:600px;
+  margin:0 auto;
+  display:flex;
+  gap:5px;
+}
+#input-area math-field {
+  flex-grow:1;
+  border:2px solid #a0a0a0;
+  border-radius:10px;
+  padding:6px;
+}
+#plot { max-width:600px; margin:20px auto; }
+</style>
+</head>
+<body>
+<div id="chat"></div>
+<div id="input-area">
+  <math-field id="question" virtual-keyboard-mode="onfocus" style="width:100%;"></math-field>
+  <input type="file" id="imgInput" accept="image/*" />
+  <button id="sendBtn">Send</button>
+</div>
+<div id="plot"></div>
+<script>
+function renderMathInChat(){
+  renderMathInElement(document.getElementById('chat'), {delimiters:[{left:'$$', right:'$$', display:true},{left:'$', right:'$', display:false}]});
+}
+async function ocrImage(file){
+  const { data:{text} } = await Tesseract.recognize(file,'eng');
+  return text;
+}
+document.getElementById('imgInput').addEventListener('change', async (e)=>{
+  if(e.target.files[0]){
+    const text = await ocrImage(e.target.files[0]);
+    document.getElementById('question').value = text;
+  }
+});
+function addMessage(text, cls){
+  const div = document.createElement('div');
+  div.className='message '+cls;
+  div.textContent=text;
+  document.getElementById('chat').appendChild(div);
+  renderMathInChat();
+  div.scrollIntoView();
+}
+document.getElementById('sendBtn').addEventListener('click', async ()=>{
+  const questionField=document.getElementById('question');
+  const question=questionField.value;
+  if(!question.trim()) return;
+  addMessage(question,'user');
+  questionField.value='';
+  const thinking=document.createElement('div');
+  thinking.className='message bot';
+  thinking.textContent='🤔 Thinking...';
+  document.getElementById('chat').appendChild(thinking);
+  const res = await fetch('http://127.0.0.1:5000/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({question})});
+  const data = await res.json();
+  thinking.remove();
+  addMessage(data.final_output || 'No answer','bot');
+  if(data.result && data.result.includes('Plotly')){
+    const plotDiv=document.getElementById('plot');
+    plotDiv.innerHTML='';
+    try{eval(data.result);}catch(e){}
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a kid friendly chat interface with MathLive, KaTeX, Plotly and OCR support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6846c32afb308326bbb4f45f4deb4fa4