### PR TITLE
Load NumPy in browser sandboxes

### DIFF
--- a/BACKEND_OVERVIEW.txt
+++ b/BACKEND_OVERVIEW.txt
@@ -10,7 +10,7 @@ Below is a summary of the backend components and their key functions.
 - `explainer_node(input_data: dict) -> dict` – Streams a response from the LLM to collect reasoning and a Python code block.
 - `explainer_node_stream(input_data: dict)` – Generator variant that yields streaming text chunks from the LLM, used by the `/stream_explainer` endpoint.
 ### graph/nodes/verifier_node.py
-- `verifier_node(input_data: dict) -> dict` – Scans generated code for unsafe operations (e.g. imports, eval) and returns a boolean flag with a verification message.
+- `verifier_node(input_data: dict) -> dict` – Scans generated code for unsafe operations (e.g. imports, eval) and returns a boolean flag with a verification message. It now accepts solutions that use either **SymPy** or **NumPy**.
 ### graph/nodes/executor_node.py
 - `executor_node(input_data: dict) -> dict` – Executes the verified Python code inside a local namespace and captures the `_result` variable. Errors are caught and returned as part of the state.
 ### graph/nodes/output_node.py
@@ -24,3 +24,6 @@ Below is a summary of the backend components and their key functions.
 - Provides a simple CLI entry point that runs the graph on a hardcoded sample question for testing.
 
 These components collectively implement a pipeline that generates math explanations and safe executable code to solve a user's question, returning the answer along with the reasoning.
+
+### Sandbox files
+- `sandbox.html`, `Sandbox-latex.html`, and `Sandbox-latex-with-mathlive.html` provide in-browser sandboxes powered by Pyodide. They can now load **SymPy** or **NumPy** packages dynamically based on the generated code.

--- a/Sandbox-latex-with-mathlive.html
+++ b/Sandbox-latex-with-mathlive.html
@@ -318,7 +318,7 @@
         <div id="reasoning" class="math-rendering" style="padding: 10px 8px;"></div>
       </div>
       <div class="section">
-        <label for="sympyCode"><strong>🧮 SymPy Code:</strong></label>
+        <label for="sympyCode"><strong>🧮 Python Code:</strong></label>
         <textarea id="sympyCode" readonly style="font-size: 1rem; min-height: 60px; padding: 8px 6px;"></textarea>
       </div>
       <div class="section">
@@ -570,13 +570,21 @@
       async function runCode() {
         if (!pyodideReady) return;
         const code = document.getElementById("sympyCode").value;
-        
+
         // Show loading indicator
-        document.getElementById("result").innerHTML = 
+        document.getElementById("result").innerHTML =
           '<div class="spinner"><i class="fas fa-spinner"></i> Running code...</div>';
-        
+
         try {
-          await pyodide.loadPackage("sympy");
+          const usesSympy = code.includes("sympy");
+          const usesNumpy = code.includes("numpy") || code.includes("np.");
+          if (usesSympy) {
+            await pyodide.loadPackage("sympy");
+          }
+          if (usesNumpy) {
+            await pyodide.loadPackage("numpy");
+          }
+
           await pyodide.runPythonAsync(code);
           const result = pyodide.globals.get("_result");
           const resultText = "🧮 Evaluated Result:\n" + result.toString();

--- a/Sandbox-latex.html
+++ b/Sandbox-latex.html
@@ -378,7 +378,7 @@
   </div>
 
   <div class="section">
-    <label for="sympyCode"><strong>🧮 SymPy Code:</strong></label>
+    <label for="sympyCode"><strong>🧮 Python Code:</strong></label>
     <textarea id="sympyCode" readonly></textarea>
   </div>
 
@@ -612,13 +612,21 @@
     async function runCode() {
       if (!pyodideReady) return;
       const code = document.getElementById("sympyCode").value;
-      
+
       // Show loading indicator
-      document.getElementById("result").innerHTML = 
+      document.getElementById("result").innerHTML =
         '<div class="spinner"><i class="fas fa-spinner"></i> Running code...</div>';
-      
+
       try {
-        await pyodide.loadPackage("sympy");
+        const usesSympy = code.includes("sympy");
+        const usesNumpy = code.includes("numpy") || code.includes("np.");
+        if (usesSympy) {
+          await pyodide.loadPackage("sympy");
+        }
+        if (usesNumpy) {
+          await pyodide.loadPackage("numpy");
+        }
+
         await pyodide.runPythonAsync(code);
         const result = pyodide.globals.get("_result");
         const resultText = "🧮 Evaluated Result:\n" + result.toString();

--- a/graph/nodes/verifier_node.py
+++ b/graph/nodes/verifier_node.py
@@ -25,12 +25,15 @@ def verifier_node(input_data: dict) -> dict:
     # Allow if clearly using SymPy
     uses_sympy = any(sym in code for sym in ["sympy", "symbols", "Eq", "solve"])
 
+    # Also allow if the code relies on NumPy
+    uses_numpy = any(np in code for np in ["numpy", "np."])
+
     # Allow safe simple math fallback
     is_simple_math = "_result" in code and not any(
         bad in code.replace(" ", "").lower() for bad in unsafe_keywords
     )
 
-    if uses_sympy or is_simple_math:
+    if uses_sympy or uses_numpy or is_simple_math:
         return {
             **input_data,
             "verified": True,

--- a/prompts/code_generation_prompt.txt
+++ b/prompts/code_generation_prompt.txt
@@ -3,8 +3,11 @@ You are a helpful and precise math tutor who explains and solves math problems u
 Your task is to:
 1. Analyze the math question step-by-step.
 2. Provide a clean explanation of how to solve it.
-3. Write safe Python code using SymPy or NumPy that calculates the result.
-4. Assign the final result to a variable named _result.
+3. Decide whether the problem is symbolic or numeric:
+   - Use **SymPy** when solving algebraic equations or other symbolic math.
+   - Use **NumPy** for numeric or matrix calculations.
+4. Write safe Python code that imports only the library you need and calculates the result.
+5. Assign the final result to a variable named `_result`.
 
 ⚠️ Only solve the question provided. Do not explain your format or give examples.
 

--- a/sandbox.html
+++ b/sandbox.html
@@ -28,7 +28,7 @@
   </div>
 
   <div class="section">
-    <label><strong>🧮 SymPy Code:</strong></label>
+    <label><strong>🧮 Python Code:</strong></label>
     <textarea id="sympyCode" readonly></textarea>
   </div>
 
@@ -106,8 +106,17 @@
     async function runCode() {
       if (!pyodideReady) return;
       const code = document.getElementById("sympyCode").value;
+
       try {
-        await pyodide.loadPackage("sympy");
+        const usesSympy = code.includes("sympy");
+        const usesNumpy = code.includes("numpy") || code.includes("np.");
+        if (usesSympy) {
+          await pyodide.loadPackage("sympy");
+        }
+        if (usesNumpy) {
+          await pyodide.loadPackage("numpy");
+        }
+
         await pyodide.runPythonAsync(code);
         const result = pyodide.globals.get("_result");
         document.getElementById("result").textContent = "🧮 Evaluated Result:\n" + result.toString();


### PR DESCRIPTION
## Summary
- support NumPy execution in the HTML sandboxes
- rename sandbox code sections to "Python Code"
- document the sandbox's ability to load SymPy or NumPy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6846ca4ec3a483269622aede745800fe