### PR TITLE
Add parent signup questionnaire nodes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify, Response
 from flask_cors import CORS
 from graph.edges import app as langgraph_app
+from graph.signup_edges import signup_app
 
 app = Flask(__name__)
 CORS(app)  # ✅ Allow frontend HTML to call this API
@@ -37,6 +38,19 @@ def stream_explainer():
         for chunk in explainer_node_stream({"question": question}):
             yield chunk
     return Response(generate(), mimetype="text/plain")
+
+@app.route("/signup_questionnaire", methods=["POST"])
+def signup_questionnaire():
+    data = request.get_json()
+    parent_name = data.get("parent_name", "")
+    if not parent_name:
+        return jsonify({"error": "No parent name provided"}), 400
+    result = signup_app.invoke({"parent_name": parent_name})
+    return jsonify({
+        "parent_name": parent_name,
+        "questionnaire": result.get("questionnaire", ""),
+        "final_output": result.get("final_output", "")
+    })
 
 
 if __name__ == "__main__":

--- a/graph/nodes/questionnaire_node.py
+++ b/graph/nodes/questionnaire_node.py
@@ -1,0 +1,30 @@
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+api_key = os.getenv("DEEPSEEK_API_KEY")
+
+client = OpenAI(
+    api_key=api_key,
+    base_url="https://api.deepseek.com"
+)
+
+def questionnaire_node(input_data: dict) -> dict:
+    """Generate a questionnaire for the parent."""
+    parent_name = input_data["parent_name"]
+    with open("prompts/parent_questionnaire_prompt.txt", "r", encoding="utf-8") as f:
+        prompt_template = f.read()
+    prompt = prompt_template.replace("{parent_name}", parent_name)
+    response = client.chat.completions.create(
+        model="deepseek-chat",
+        messages=[
+            {"role": "system", "content": "You are a friendly assistant."},
+            {"role": "user", "content": prompt}
+        ]
+    )
+    questionnaire = response.choices[0].message.content.strip()
+    return {
+        "parent_name": parent_name,
+        "questionnaire": questionnaire
+    }

--- a/graph/nodes/signup_input_node.py
+++ b/graph/nodes/signup_input_node.py
@@ -1,0 +1,7 @@
+def signup_input_node(input_data: dict) -> dict:
+    """First node for parent sign up. Validates parent name."""
+    parent_name = input_data.get("parent_name", "").strip()
+    if not parent_name:
+        raise ValueError("No parent name provided.")
+    print(f"[Signup Input Node] Received parent name: {parent_name}")
+    return {"parent_name": parent_name}

--- a/graph/nodes/signup_output_node.py
+++ b/graph/nodes/signup_output_node.py
@@ -1,0 +1,6 @@
+def signup_output_node(input_data: dict) -> dict:
+    parent_name = input_data.get("parent_name", "")
+    questionnaire = input_data.get("questionnaire", "")
+    final_output = f"Hello {parent_name}, please answer the following questions:\n{questionnaire}"
+    input_data["final_output"] = final_output
+    return input_data

--- a/graph/signup_edges.py
+++ b/graph/signup_edges.py
@@ -1,0 +1,26 @@
+from langgraph.graph import StateGraph, END
+from typing import TypedDict
+
+from graph.nodes.signup_input_node import signup_input_node
+from graph.nodes.questionnaire_node import questionnaire_node
+from graph.nodes.signup_output_node import signup_output_node
+
+class SignupState(TypedDict):
+    parent_name: str
+    questionnaire: str
+    final_output: str
+
+builder = StateGraph(SignupState)
+
+builder.add_node("signup_input", signup_input_node)
+builder.add_node("questionnaire", questionnaire_node)
+builder.add_node("signup_output", signup_output_node)
+
+builder.set_entry_point("signup_input")
+builder.add_edge("signup_input", "questionnaire")
+builder.add_edge("questionnaire", "signup_output")
+builder.add_edge("signup_output", END)
+
+signup_graph = builder.compile()
+
+signup_app = signup_graph

--- a/prompts/parent_questionnaire_prompt.txt
+++ b/prompts/parent_questionnaire_prompt.txt
@@ -1,0 +1,4 @@
+You are an educational assistant helping parents set up the math learning app.
+Please provide a short questionnaire of 3-5 numbered questions to learn about
+their child's needs. Use the parent's name when available.
+Parent name: {parent_name}


### PR DESCRIPTION
## Summary
- add nodes for a parent signup flow
- build a new graph compiling those nodes
- expose signup_questionnaire endpoint in `app.py`
- include prompt for questionnaire generation

## Testing
- `pip install -r requirements.txt`
- `pip install python-dotenv`
- `pytest -q` *(fails: fixture 'question' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ba126fd88326a22585022e48fd76